### PR TITLE
APPS-1808: Custom trait window in snapshot test

### DIFF
--- a/Sources/SnapshotTesting/CustomTraitWindow.swift
+++ b/Sources/SnapshotTesting/CustomTraitWindow.swift
@@ -1,0 +1,31 @@
+//
+//  CustomTraitWindow.swift
+//  swift-snapshot-testing
+//
+//  Created by Kashish Verma on 07/10/25.
+//  Copyright © 2025 Carsales.com.au. All rights reserved.
+//
+
+import UIKit
+
+/// Custom UIWindow subclass that allows us to override the trait collection
+public class CustomTraitWindow: UIWindow {
+    var customTraitCollection: UITraitCollection
+
+    override public var traitCollection: UITraitCollection {
+        return customTraitCollection
+    }
+
+    init(config: ViewImageConfig) {
+        self.customTraitCollection = UITraitCollection(traitsFrom: [
+            UIWindow().traitCollection,
+            config.traits
+        ])
+        super.init(frame: CGRect(origin: .zero, size: config.size ?? .zero))
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Sources/SnapshotTesting/SnapshotTestUtils.swift
+++ b/Sources/SnapshotTesting/SnapshotTestUtils.swift
@@ -117,7 +117,8 @@ public class SnapshotTestUtils {
                 if let configSize = config.imageConfig.size {
                     size.width = configSize.width
                 }
-                let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+                let window = CustomTraitWindow(config: config.imageConfig)
+                window.frame = CGRect(origin: .zero, size: size)
                 window.rootViewController = viewController
 
                 viewController.beginAppearanceTransition(true, animated: false)


### PR DESCRIPTION
Added custom trait window in snapshot test

I have tested this change in Torq and in retail app and found that everything is working fine as expected. 